### PR TITLE
Add gh-pages deployment scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "autoprefixer": "^10.4.21",
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
+        "gh-pages": "^6.0.0",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.19.1",
@@ -9143,6 +9144,10 @@
       "peerDependencies": {
         "zod": "^3.18.0"
       }
+    },
+    "node_modules/gh-pages": {
+      "version": "6.0.0",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -97,6 +99,7 @@
     "autoprefixer": "^10.4.21",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
+    "gh-pages": "^6.0.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
@@ -105,5 +108,6 @@
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
-  }
+  },
+  "homepage": "https://<username>.github.io/AdGenieLandingPage/"
 }


### PR DESCRIPTION
## Summary
- install `gh-pages` as a dev dependency
- configure deployment scripts and homepage

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685ba8676ac883238fe044eb656fd3b6