### PR TITLE
Update deployment config

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d dist/public"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -109,5 +109,5 @@
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
   },
-  "homepage": "https://<username>.github.io/AdGenieLandingPage/"
+  "homepage": "https://ra1111.github.io/AdGenieLandingPage/"
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig({
+  base: '/AdGenieLandingPage/',
   plugins: [
     react(),
     runtimeErrorOverlay(),


### PR DESCRIPTION
## Summary
- configure Vite to serve from `/AdGenieLandingPage/`
- set the GitHub Pages URL in `package.json`
- publish the `dist/public` folder via gh-pages

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685bb190b9948323aa4f3e15176c6066