### PR TITLE
Fix dev base path and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ These features are defined in [`client/src/lib/constants.ts`](client/src/lib/con
    npm run dev
    ```
    This runs the Express server with Vite in middleware mode for hot reloading.
+   The app is available at `http://localhost:5000`.
 
 ## Building & Deploying to GitHub Pages
 The project can be built and deployed to GitHub Pages using the provided scripts in `package.json`:
@@ -46,5 +47,7 @@ The project can be built and deployed to GitHub Pages using the provided scripts
    ```bash
    npm run deploy
    ```
-
 After deployment, your site will be available at the URL specified in the `homepage` field.
+The Vite configuration automatically uses `/AdGenieLandingPage/` as the base
+path when building for production, while local development runs from the root
+path.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
-export default defineConfig({
-  base: '/AdGenieLandingPage/',
+export default defineConfig(async ({ command }) => ({
+  base: command === "serve" ? "/" : "/AdGenieLandingPage/",
   plugins: [
     react(),
     runtimeErrorOverlay(),
@@ -29,4 +29,4 @@ export default defineConfig({
     outDir: path.resolve(import.meta.dirname, "dist/public"),
     emptyOutDir: true,
   },
-});
+}));


### PR DESCRIPTION
## Summary
- handle base path differently in dev vs production
- clarify dev server info and deployment details in README

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685bb6122e188323a90c6dd6f7fd1fa2